### PR TITLE
Run Emcee pod in its own ServiceAccount

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,6 +5,86 @@ metadata:
     control-plane: controller-manager
   name: system
 ---
+# Notes
+# 1. This RBAC is hand generated, I don't know if KubeBuilder should be used instead
+# 2. This RBAC has been tested with passthrough.  More permissions will be needed for the things limited-trust creates
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: emcee
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: system
+  name: cm-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: emcee-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role  # defined in config/rbac/role.yaml
+subjects:
+- kind: ServiceAccount
+  name: emcee
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-cm
+  namespace: system
+subjects:
+- kind: ServiceAccount
+  name: emcee
+  namespace: system
+roleRef:
+  kind: Role
+  name: cm-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: emcee-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - serviceentries
+  verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: emcee-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: emcee-controller
+subjects:
+- kind: ServiceAccount
+  name: emcee
+  namespace: system
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,11 +102,14 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      serviceAccountName: emcee
       containers:
       - command:
         - /manager
         args:
         - --enable-leader-election
+        - --grpc-server-addr
+        - :50052
         image: controller:latest
         imagePullPolicy: Always
         name: manager

--- a/pkg/discovery/client.go
+++ b/pkg/discovery/client.go
@@ -303,7 +303,7 @@ func client(ctx context.Context, sbr *controllers.ServiceBindingReconciler, disc
 			}
 			log.Infof("Received ESDA Discovery message: <%v>", in)
 			createServiceBindings(sbr, in, disc)
-			log.Infof("Processd ESDA Discovery message")
+			log.Infof("Processed ESDA Discovery message")
 		}
 	}()
 


### PR DESCRIPTION
Resolves https://github.com/istio-ecosystem/emcee/issues/42

To use, do the following, replacing `esnible` with your own Docker Hub ID
```
kubectl apply -f config/rbac/role.yaml
cat config/manager/manager.yaml | sed 's/controller:latest/docker.io\/esnible\/controller:latest/' | kubectl apply -f -
```

To review this you must understand that I created this by hand.  I ran Emcee as a pod and added things to manager.yaml until it stopped grousing about insufficient permissions.  If there is a better, KubeBuilder, way to generate the needed RBAC, then this PR should not be merged.